### PR TITLE
[T] stray - German, New Norwegian, Norwegian, Swedish

### DIFF
--- a/sources/s/stray.md
+++ b/sources/s/stray.md
@@ -28,18 +28,18 @@ Grammar:     Masculine
 New Norwegian
 =============
 
-Translation: (ein) lauseng ; lausengen ; lausengar ; lausengane
+Translation: (eit) lausdyr ; lausdyret ; lausdyr ; lausdyra
 
-Grammar:     Masculine
+Grammar:     Neuter
 
 
 
 Norwegian
 =========
 
-Translation: (en) løsing ; løsingen ; løsinger ; løsingene
+Translation: (et) løsdyr ; løsdyret ; løsdyr ; løsdyrene
 
-Grammar:     Masculine
+Grammar:     Neuter
 
 
 

--- a/sources/s/stray.md
+++ b/sources/s/stray.md
@@ -1,0 +1,51 @@
+Defaults
+========
+
+Structure: Singular, Indefinite ; Singular, Definite ; Plural, Indefinite ; Plural, Definite
+
+Grammar:   Noun
+
+
+
+English
+=======
+
+Translation: (a) stray ; the stray ; strays ; the strays
+
+Grammar:     Neuter
+
+
+
+German
+======
+
+Translation: (ein) Streuner ; der Streuner ; Streuner ; die Streuner
+
+Grammar:     Masculine
+
+
+
+New Norwegian
+=============
+
+Translation: (ein) lauseng ; lausengen ; lausengar ; lausengane
+
+Grammar:     Masculine
+
+
+
+Norwegian
+=========
+
+Translation: (en) løsing ; løsingen ; løsinger ; løsingene
+
+Grammar:     Masculine
+
+
+
+Swedish
+=======
+
+Translation: (en) strykare ; strykaren ; strykare ; strykarna
+
+Grammar:     Common


### PR DESCRIPTION
Translation of the noun: stray

Note: New Norwegian and Norwegian translations are unconfirmed.